### PR TITLE
Fixed overwriting of sprites with duplicate coords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,3 @@
 __pycache__
 atlas/
+.venv

--- a/pokatlas.py
+++ b/pokatlas.py
@@ -17,12 +17,12 @@ class Atlas():
     
     def add_sprite(self, name, attributes):
         self.sprites[name] = attributes
-
-    def get_sprites(self) -> dict:
-        return self.sprites
     
     def add_sprite_hash(self, name, hash):
         self.sprite_hashes[name] = hash
+
+    def get_sprites(self) -> dict:
+        return self.sprites
 
 def get_atlas(path: pathlib.Path) -> Atlas:
     t = path.read_text().strip().split('\n')
@@ -48,8 +48,7 @@ def get_atlas(path: pathlib.Path) -> Atlas:
     return atlas
 
 def get_image_hash(image_path: pathlib.Path) -> str:
-    with open(image_path, "rb") as f:
-        return hashlib.md5(f.read()).hexdigest()
+    return hashlib.md5(image_path.read_bytes()).hexdigest()
 
 def decomp(atlas: Atlas):
     atlas_dir = atlas.atlas_path.parent

--- a/pokatlas.py
+++ b/pokatlas.py
@@ -1,5 +1,7 @@
 from PIL import Image
 import pathlib
+import hashlib
+from collections import Counter
 
 
 class Atlas():
@@ -11,6 +13,7 @@ class Atlas():
         self.img_filter = img_filter
         self.repeat = repeat
         self.sprites = {}
+        self.sprite_hashes = {}
     
     def add_sprite(self, name, attributes):
         self.sprites[name] = attributes
@@ -18,6 +21,8 @@ class Atlas():
     def get_sprites(self) -> dict:
         return self.sprites
     
+    def add_sprite_hash(self, name, hash):
+        self.sprite_hashes[name] = hash
 
 def get_atlas(path: pathlib.Path) -> Atlas:
     t = path.read_text().strip().split('\n')
@@ -42,6 +47,10 @@ def get_atlas(path: pathlib.Path) -> Atlas:
 
     return atlas
 
+def get_image_hash(image_path: pathlib.Path) -> str:
+    with open(image_path, "rb") as f:
+        return hashlib.md5(f.read()).hexdigest()
+
 def decomp(atlas: Atlas):
     atlas_dir = atlas.atlas_path.parent
     atlas_img = Image.open(atlas_dir / atlas.img_name)
@@ -58,6 +67,40 @@ def decomp(atlas: Atlas):
         sprite = atlas_img.crop((left, top, right, bottom))
 
         sprite.save(sprites_dir / f'{sprite_name}.png')
+        atlas.add_sprite_hash(sprite_name, get_image_hash(sprites_dir / f'{sprite_name}.png'))
+
+def find_duplicates(atlas: Atlas) -> list:
+    sprites = atlas.get_sprites()
+
+    attributes = sprites.values()
+    coord_counts = Counter(d['xy'] for d in attributes)
+    duplicate_coords = {coord for coord,
+                        count in coord_counts.items() if count > 1}
+
+    result = [sprite_name for sprite_name,
+              d in sprites.items() if d['xy'] in duplicate_coords]
+
+    return result
+
+def check_duplicates(atlas: Atlas):
+    atlas_dir = atlas.atlas_path.parent
+    sprites_dir = atlas_dir / 'sprites'
+    duplicates = find_duplicates(atlas)
+
+    modified_dupe_sprites = []
+
+    for sprite_name, attributes in atlas.get_sprites().items():
+        if atlas.sprite_hashes[sprite_name] != get_image_hash(sprites_dir / f'{sprite_name}.png'):
+            if sprite_name in duplicates:
+                modified_dupe_sprites.append((sprite_name, attributes))
+
+    for sprite_name, attributes in modified_dupe_sprites:
+
+        atlas.get_sprites().pop(sprite_name)
+        atlas.add_sprite(sprite_name, attributes)
+
+        removed_hash = atlas.sprite_hashes.pop(sprite_name)
+        atlas.add_sprite_hash(sprite_name, removed_hash)
         
 def rebuild(atlas: Atlas):
     canvas = Image.new('RGBA', tuple(map(int, atlas.img_size.split(', '))), (255,255,255,0))

--- a/ui/mainwindow.py
+++ b/ui/mainwindow.py
@@ -38,7 +38,7 @@ from PySide6.QtWidgets import (
     QMessageBox,
 )
 
-from pokatlas import decomp, rebuild, get_atlas
+from pokatlas import decomp, check_duplicates, rebuild, get_atlas
 
 WINDOW_WIDTH = 800
 WINDOW_HEIGHT = 400
@@ -273,6 +273,7 @@ class MainWindow(QMainWindow):
         self.sprite_list.setCurrentIndex(self.sprite_list.indexAt(QPoint(0,0)))
 
     def saveAtlas(self):
+        check_duplicates(self.atlas)
         rebuild(self.atlas)
         self.openDirectory(self.output_dir)
 


### PR DESCRIPTION
### Summary
This pull request addresses the issue described in #1 where icons in the spritesheet that are used for multiple entries would not update correctly when a single icon is updated, leading to it being overwritten with the old image.

### Related Issues
Fixes #1 (but without generating a new Atlas file).

### Details
- Ensures that if a user replaces a sprite that is a duplicate, it will be placed on the spritesheet last to prevent overwriting the image.
- Adds functionality to track the names of sprites that use images referred to by multiple sprites.
- Adds functionality to track which sprites have been updated by the user through image hashing including non-dupes.

### Edge Cases
- If an icon used under multiple sprite names is changed twice in different places, the one changed last (in the order listed in the UI) will take precedence. This means the later image overwrites the first one, which is noticeable if using images of different sizes.
- Further improvements may require generating a new Atlas file and spritesheet that separates icons with duplicate sprite names into individual icons.

### Demo
With the implemented changes, if a sprite such as `monster_type_0_en.png` is replaced with a substitute, the spritesheet should be updated as shown below (top left).
![main](https://github.com/user-attachments/assets/777b3e67-c9f4-40ee-9f88-d5f8b9976a21)
